### PR TITLE
Make GitHub detect the block files as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+real/* linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect the block files in the `real` directory as Forth.

Thanks!